### PR TITLE
Changed output of converter to JPEG

### DIFF
--- a/src/bin/converter.rs
+++ b/src/bin/converter.rs
@@ -1,11 +1,12 @@
 use std::env;
 use std::fs::File;
-use std::error::Error;
-use std::io::prelude::*;
 use std::io::BufWriter;
+use image::ColorType;
+
 extern crate time;
 extern crate imagepipe;
 extern crate rawloader;
+extern crate image;
 
 fn usage() {
   println!("converter <file> [outfile]");
@@ -56,14 +57,15 @@ fn main() {
 
   let uf = match File::create(outfile) {
     Ok(val) => val,
-    Err(e) => {error(e.description());unreachable!()},
+    Err(e) => {
+      error(format!("Error: {}", e).as_ref());
+      unreachable!()
+    }
   };
   let mut f = BufWriter::new(uf);
-  let preamble = format!("P6 {} {} {}\n", decoded.width, decoded.height, 255).into_bytes();
-  if let Err(err) = f.write_all(&preamble) {
-    error(err.description());
-  }
-  if let Err(err) = f.write_all(&decoded.data) {
-    error(err.description());
-  }
+
+  let mut jpg_encoder = image::jpeg::JPEGEncoder::new_with_quality(&mut f, 80);
+  jpg_encoder
+    .encode(&decoded.data, decoded.width as u32, decoded.height as u32, ColorType::RGB(8))
+    .expect("Encoding image in JPEG format failed.");
 }


### PR DESCRIPTION
Hi Pedro,

great work developing a whole image pipeline from scratch in rust !!

I have changed the `converter` executable to export the raw image in JPEG-Format using functions from the `image` crate. I think it's the more common format and will make the `converter`-executable more usable to other users.

If you like this you can merge this, if not maybe consider it as an example for other users.

Best regards,
Maximilian