### PR TITLE
Fixed deprecated time measurement

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,6 @@ categories = ["multimedia::images"]
 edition = "2018"
 
 [dependencies]
-time = "0.2"
 lazy_static = "1"
 rayon = "1"
 serde = "1"

--- a/src/bin/converter.rs
+++ b/src/bin/converter.rs
@@ -3,7 +3,8 @@ use std::fs::File;
 use std::error::Error;
 use std::io::prelude::*;
 use std::io::BufWriter;
-extern crate time;
+use std::time::Instant;
+
 extern crate imagepipe;
 extern crate rawloader;
 
@@ -31,13 +32,13 @@ fn main() {
   };
   println!("Loading file \"{}\" and saving it as \"{}\"", file, outfile);
 
-  let from_time = time::PrimitiveDateTime::now();
+  let from_time = Instant::now();
   let image = match rawloader::decode_file(file) {
     Ok(val) => val,
     Err(e) => {error(&e.to_string());unreachable!()},
   };
-  let to_time = time::PrimitiveDateTime::now();
-  println!("Decoded in {} ms", (to_time-from_time).whole_milliseconds());
+  let duration = from_time.elapsed();
+  println!("Decoded in {} ms", duration.as_millis());
 
   println!("Found camera \"{}\" model \"{}\"", image.make, image.model);
   println!("Found clean named camera \"{}\" model \"{}\"", image.clean_make, image.clean_model);

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -4,7 +4,6 @@ use crate::opbasics::*;
 extern crate rawloader;
 extern crate multicache;
 use self::multicache::MultiCache;
-extern crate time;
 extern crate serde;
 extern crate serde_yaml;
 use self::serde::{Serialize,Deserialize};
@@ -14,6 +13,7 @@ use std::sync::Arc;
 use std::io::Write;
 use std::path::Path;
 use std::hash::{Hash, Hasher};
+use std::time::Instant;
 
 /// A RawImage processed into a full 8bit sRGB image with levels and gamma
 ///
@@ -29,10 +29,10 @@ pub struct SRGBImage {
 pub type PipelineCache = MultiCache<BufHash, OpBuffer>;
 
 fn do_timing<O, F: FnMut() -> O>(name: &str, mut closure: F) -> O {
-  let from_time = time::PrimitiveDateTime::now();
+  let from_time = Instant::now();
   let ret = closure();
-  let to_time = time::PrimitiveDateTime::now();
-  debug!("{} ms for '{}'", (to_time-from_time).whole_milliseconds(), name);
+  let duration = from_time.elapsed();
+  debug!("{} ms for '{}'", duration.as_millis(), name);
 
   ret
 }


### PR DESCRIPTION
Hi Pedro,

I removed the `time` dependency due to the deprecated `now()` method in the `time` crate.

Best regards,
Maximilian 